### PR TITLE
[EV-2594] Upgrade alpine image to golang v1.18.8

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,7 +16,7 @@ rm -Rf ${SRC_DIR}/${RELEASE_DIR}
 mkdir -p ${SRC_DIR}/${RELEASE_DIR}
 mkdir -p ${OUTPUT_DIR}
 
-$DOCKER run -ti -v ${SRC_DIR}:/go/src/github.com/containernetworking/plugins:z --rm golang:1.18-alpine \
+$DOCKER run -ti -v ${SRC_DIR}:/go/src/github.com/containernetworking/plugins:z --rm golang:1.18.8-alpine \
 /bin/sh -xe -c "\
     apk --no-cache add bash tar;
     cd /go/src/github.com/containernetworking/plugins; umask 0022;


### PR DESCRIPTION
Upgrade alpine image to go version `1.18.8`

* Could the reviewer also create a new release - Follow the naming convention
    * There is a list of assets that I will have to provide and should be uploaded as part of the release.
       `release-v1.1.1-calico+go-1.18.8` - The contents have been built and verified on go1.18.8
       

