### PR TITLE
[EV-2957] Upgrade go to v1.18.9

### DIFF
--- a/plugins/meta/portmap/portmap_integ_test.go
+++ b/plugins/meta/portmap/portmap_integ_test.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/containernetworking/cni/libcni"
-	"github.com/containernetworking/cni/pkg/types/100"
+	types100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 	"github.com/coreos/go-iptables/iptables"
@@ -207,7 +207,7 @@ var _ = Describe("portmap integration tests", func() {
 
 				// Verify iptables rules are gone
 				_, err = ipt.List("nat", dnatChainName)
-				Expect(err).To(MatchError(ContainSubstring("iptables: No chain/target/match by that name.")))
+				Expect(err).To(HaveOccurred())
 
 				// Check that everything succeeded *after* we clean up the network
 				if !contOK {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,7 +16,7 @@ rm -Rf ${SRC_DIR}/${RELEASE_DIR}
 mkdir -p ${SRC_DIR}/${RELEASE_DIR}
 mkdir -p ${OUTPUT_DIR}
 
-$DOCKER run -ti -v ${SRC_DIR}:/go/src/github.com/containernetworking/plugins:z --rm golang:1.18.8-alpine \
+$DOCKER run -ti -v ${SRC_DIR}:/go/src/github.com/containernetworking/plugins:z --rm golang:1.18.9-alpine \
 /bin/sh -xe -c "\
     apk --no-cache add bash tar;
     cd /go/src/github.com/containernetworking/plugins; umask 0022;


### PR DESCRIPTION
- Upgrade `go` to `v1.18.9`

- Resolve linux test failure `[0.3.0] forwards a TCP port on ipv4 [It]`

> GitHub Actions recently updated ubuntu-latest to 22.04 [1], which now
> defaults to nfttables (rather than iptables-legacy) [2]. The portmap
> tests in this project are written with the expectation that expected
> error message for one test is in the iptables-legacy format.
> 
> This commit updates the check to make it work for both the
> iptables-legecy and iptables-nftables variants.
> 
> References:
> [1]: https://github.com/actions/runner-images/commit/4aba37bd3b8df82c3b27e7c2448556e966a8b41e
> [2]: https://ubuntu.com/blog/whats-new-in-security-for-ubuntu-22-04-lts
> 

This issue has been addressed in the main line:
https://github.com/containernetworking/plugins/commit/6b30e290d20a211cdd5465c22ecf69d0eda068c0